### PR TITLE
Stream‐decode WAV files in chunks to prevent OutOfMemory during transcription

### DIFF
--- a/shared/src/androidMain/kotlin/com/module/notelycompose/platform/Transcriper.android.kt
+++ b/shared/src/androidMain/kotlin/com/module/notelycompose/platform/Transcriper.android.kt
@@ -7,9 +7,10 @@ import android.os.Environment
 import androidx.core.content.ContextCompat
 import audio.utils.LauncherHolder
 import com.module.notelycompose.core.debugPrintln
-import com.module.notelycompose.utils.decodeWaveFile
+import com.module.notelycompose.utils.decodeWaveFileStream
 import com.whispercpp.whisper.WhisperCallback
 import com.whispercpp.whisper.WhisperContext
+import kotlinx.coroutines.flow.collectIndexed
 import kotlinx.coroutines.suspendCancellableCoroutine
 import java.io.File
 import kotlin.coroutines.resume
@@ -92,46 +93,66 @@ actual class Transcriber(
     }
 
     actual suspend fun start(
-        filePath: String, language: String,
-        onProgress : (Int) -> Unit,
-        onNewSegment : (Long, Long,String) -> Unit,
-        onComplete : () -> Unit
+        filePath: String,
+        language: String,
+        onProgress: (Int) -> Unit,
+        onNewSegment: (Long, Long, String) -> Unit,
+        onComplete: () -> Unit
     ) {
-        if (!canTranscribe) {
-            return
-        }
-
+        if (!canTranscribe) return
         canTranscribe = false
 
         try {
-            debugPrintln{"Reading wave samples... "}
+            debugPrintln { "Streaming wave samples in chunks..." }
             val file = File(filePath)
-            val data = decodeWaveFile(file)
-            debugPrintln{"${data.size / (16000 / 1000)} ms\n"}
-            debugPrintln{"Transcribing data...\n"}
-            val start = System.currentTimeMillis()
-            val text = whisperContext?.transcribeData(data, language, callback = object : WhisperCallback{
-                override fun onNewSegment(startMs: Long, endMs: Long, text: String) {
-                    onNewSegment(startMs, endMs, text)
-                }
 
-                override fun onProgress(progress: Int) {
-                    onProgress(progress)
-                }
+            // 1 second of audio at 16 kHz
+            val chunkFrames = 16_000
 
-                override fun onComplete() {
-                    onComplete()
-                }
+            // track how many frames we've processed so we can report progress
+            var totalFramesRead = 0L
+            // approximate total frames from file size (minus 44 byte header):
+            val totalFrames = ((file.length() - 44) / 2 /*bytes/sample*/)
 
-            })
-            val elapsed = System.currentTimeMillis() - start
-            debugPrintln{"Done ($elapsed ms): \n$text\n"}
+            // 1) collectIndexed gives us the chunk index
+            decodeWaveFileStream(file, chunkFrames).collectIndexed { chunkIndex, floatChunk ->
+                totalFramesRead += floatChunk.size
+
+                debugPrintln { "Chunk #$chunkIndex → ${floatChunk.size} samples" }
+
+                // 2) send each chunk into Whisper
+                whisperContext?.transcribeData(
+                    floatChunk,
+                    language,
+                    callback = object : WhisperCallback {
+                        override fun onNewSegment(startMs: Long, endMs: Long, text: String) {
+                            onNewSegment(startMs, endMs, text)
+                        }
+
+                        override fun onProgress(progress: Int) {
+                            onProgress(progress)
+                        }
+
+                        override fun onComplete() {
+                            // per‑chunk completion if needed
+                        }
+                    }
+                )
+
+                // 3) fire a rough progress callback in ms
+                val progressMs =
+                    (totalFramesRead.toFloat() / totalFrames * (file.length() / 16_000)).toInt()
+                onProgress(progressMs)
+            }
+
+            debugPrintln { "All chunks processed, signaling complete." }
+            onComplete()
+
         } catch (e: Exception) {
             e.printStackTrace()
-            debugPrintln{"${e.localizedMessage}\n"}
+            debugPrintln { "Error: ${e.localizedMessage}" }
+        } finally {
+            canTranscribe = true
         }
-
-        canTranscribe = true
-
     }
 }

--- a/shared/src/androidMain/kotlin/com/module/notelycompose/utils/RiffWaveHelper.kt
+++ b/shared/src/androidMain/kotlin/com/module/notelycompose/utils/RiffWaveHelper.kt
@@ -1,9 +1,57 @@
 package com.module.notelycompose.utils
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.io.FileInputStream
+import java.io.IOException
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
+
+/**
+ * Streams decoded PCM samples from a WAV file in fixed‑size chunks.
+ *
+ * @param file           16 kHz, 16‑bit, mono WAV file.
+ * @param chunkFrames    how many audio frames (samples) per invocation.
+ *                       Smaller ⇒ lower memory but more callbacks.
+ * @return               a Flow that emits FloatArrays of up to [chunkFrames] samples.
+ */
+fun decodeWaveFileStream(
+    file: File,
+    chunkFrames: Int = 4_096
+): Flow<FloatArray> = flow {
+    FileInputStream(file).use { input ->
+        // 1) Skip WAV header (44 bytes)
+        val header = ByteArray(44)
+        if (input.read(header) != header.size) {
+            throw IOException("Unable to read WAV header")
+        }
+        // (we assume mono, 16‑bit, little endian)
+        val bytesPerSample = 2
+        val frameSizeBytes = bytesPerSample * /* channels */ 1
+
+        // 2) Now read & emit in chunks
+        val buffer = ByteArray(chunkFrames * frameSizeBytes)
+        var bytesRead: Int
+
+        while (input.read(buffer).also { bytesRead = it } > 0) {
+            val framesRead = bytesRead / frameSizeBytes
+            val floatChunk = FloatArray(framesRead)
+            val bb = ByteBuffer.wrap(buffer, 0, bytesRead)
+                .order(ByteOrder.LITTLE_ENDIAN)
+
+            for (i in 0 until framesRead) {
+                // mono: read one 16‑bit sample
+                floatChunk[i] = (bb.short / 32767f).coerceIn(-1f, 1f)
+            }
+            emit(floatChunk)
+        }
+    }
+}.flowOn(Dispatchers.IO)
+
 
 fun decodeWaveFile(file: File): FloatArray {
     val baos = ByteArrayOutputStream()
@@ -18,7 +66,9 @@ fun decodeWaveFile(file: File): FloatArray {
     return FloatArray(shortArray.size / channel) { index ->
         when (channel) {
             1 -> (shortArray[index] / 32767.0f).coerceIn(-1f..1f)
-            else -> ((shortArray[2*index] + shortArray[2*index + 1])/ 32767.0f / 2.0f).coerceIn(-1f..1f)
+            else -> ((shortArray[2 * index] + shortArray[2 * index + 1]) / 32767.0f / 2.0f).coerceIn(
+                -1f..1f
+            )
         }
     }
 }


### PR DESCRIPTION
This commit introduces streamed audio processing for transcription on Android.

- The `Transcriper.android.kt` now processes audio files in chunks using a `Flow` emitted by the new `decodeWaveFileStream` function.
- `decodeWaveFileStream` in `RiffWaveHelper.kt` reads a WAV file, skips the header, and emits decoded PCM samples in `FloatArray` chunks.
- This approach allows for processing large audio files with lower memory overhead by transcribing chunk by chunk.
- Progress reporting is updated to reflect the chunked processing.