### PR TITLE
Implement 16KB page size compliance

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,7 @@ org.jetbrains.compose.experimental.uikit.enabled=true
 kotlin.native.cacheKind=none
 
 android.ndkVersion=27.0.12077973
+
+# 16KB Page Size Support, NDK r27: Enable flexible page size support for Android 15+ devices
+android.native.buildOutput=verbose
+android.native.useNativeCompilerSettingsCache=false

--- a/lib/src/main/jni/whisper/CMakeLists.txt
+++ b/lib/src/main/jni/whisper/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
 add_link_options("LINKER:--build-id=none")
+
+# 16KB Page Size Support, linker flags for 16KB page size alignment on Android 15+ devices
+add_link_options("LINKER:-z,max-page-size=16384")
+
 project(whisper.cpp)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -15,6 +19,9 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
 
 # Disable timestamps - ADDED
 add_definitions(-DGGML_NO_TIMESTAMPS=1)
+
+# 16KB Page Size Support: Add NDK r27 flexible page size compilation flag
+add_definitions(-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON)
 
 # Path to external GGML, otherwise uses the copy in whisper.cpp.
 option(GGML_HOME "whisper: Path to external GGML source" OFF)
@@ -81,6 +88,9 @@ function(build_library target_name)
         target_link_options(${target_name} PRIVATE -Wl,--gc-sections)
         target_link_options(${target_name} PRIVATE -Wl,--exclude-libs,ALL)
         target_link_options(${target_name} PRIVATE -flto)
+
+        # 16KB Page Size Support, linker flags for 16KB page size alignment on Android 15+ devices
+        target_link_options(${target_name} PRIVATE -Wl,-z,max-page-size=16384)
     endif ()
 
     if (GGML_HOME)

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -202,6 +202,8 @@ android {
         // Force deterministic file ordering
         jniLibs {
             useLegacyPackaging = true
+            // 16KB Page Size Support: Use uncompressed native libraries
+            pickFirsts += listOf("**/libc++_shared.so", "**/libwhisper.so")
         }
 
         // Ensure reproducible DEX files


### PR DESCRIPTION
- Issue: https://github.com/tosinonikute/NotelyVoice/issues/29
- Update NDK r27 configuration for flexible page size support
- Add 16KB page size linker flags to CMake builds
- Configure uncompressed native libraries in APK packaging