### PR TITLE
Fix App crashes with NSInvalidArgumentException when deleting file wi…

### DIFF
--- a/core/audio/src/iosMain/kotlin/audio/utils/FileUtils.ios.kt
+++ b/core/audio/src/iosMain/kotlin/audio/utils/FileUtils.ios.kt
@@ -49,6 +49,11 @@ internal fun NSURL.savePickedAudioToAppStorage(): NSURL?{
 
 @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
 actual fun deleteFile(filePath: String): Boolean {
+    if (filePath.isBlank()) {
+        Napier.e { "Cannot delete file: filePath is null or empty" }
+        return false
+    }
+
     memScoped {
         val error: ObjCObjectVar<NSError?> = alloc()
         val success = NSFileManager.defaultManager.removeItemAtPath(filePath, error.ptr)


### PR DESCRIPTION
…th nil/empty path

Issue: https://github.com/tosinonikute/NotelyVoice/issues/67

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', 
reason: '*** -[NSFileManager fileSystemRepresentationWithPath:]: nil or empty path argument'
*** First throw call stack:
```