### PR TITLE
Refactor: Improve recording state management in AudioRecorderViewModel

### DIFF
--- a/shared/src/commonMain/kotlin/com/module/notelycompose/audio/ui/recorder/RecordingScreen.kt
+++ b/shared/src/commonMain/kotlin/com/module/notelycompose/audio/ui/recorder/RecordingScreen.kt
@@ -36,9 +36,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -58,6 +56,7 @@ import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.module.notelycompose.audio.presentation.AudioRecorderViewModel
 import com.module.notelycompose.core.debugPrintln
 import com.module.notelycompose.notes.presentation.detail.TextEditorViewModel
@@ -92,16 +91,8 @@ fun RecordingScreen(
     viewModel: AudioRecorderViewModel = koinViewModel(),
     editorViewModel: TextEditorViewModel
 ) {
-    val recordingState by viewModel.audioRecorderPresentationState.collectAsState()
-    var screenState by remember { mutableStateOf(ScreenState.Initial) }
-
-    DisposableEffect(Unit){
-        viewModel.setupRecorder()
-        onDispose {
-            viewModel.onStopRecording()
-            viewModel.finishRecorder()
-        }
-    }
+    val recordingState by viewModel.audioRecorderPresentationState.collectAsStateWithLifecycle()
+    val screenState by viewModel.uiState.collectAsStateWithLifecycle()
 
     Box(
         modifier = Modifier
@@ -115,9 +106,7 @@ fun RecordingScreen(
             ScreenState.Initial -> RecordingInitialScreen(
                 onNavigateBack = navigateBack,
                 onTapToRecord = {
-                    viewModel.onStartRecording(noteId) {
-                        screenState = ScreenState.Recording
-                    }
+                    viewModel.onStartRecording(noteId)
                 },
                 onStopRecording = viewModel::onStopRecording
             )
@@ -127,7 +116,6 @@ fun RecordingScreen(
                 onStopRecording = {
                     debugPrintln { "onStop recording" }
                     viewModel.onStopRecording()
-                    screenState = ScreenState.Success
                 },
                 onNavigateBack = navigateBack,
                 isRecordPaused = recordingState.isRecordPaused,


### PR DESCRIPTION
This commit refactors the recording state management in `AudioRecorderViewModel`.

- Replaced `collectAsState` with `collectAsStateWithLifecycle` for better lifecycle awareness in `RecordingScreen`.
- Moved screen state management (`ScreenState`) into `AudioRecorderViewModel` from `RecordingScreen`.
- Simplified `onStartRecording` and `onStopRecording` by removing the `updateUI` callback and directly updating the screen state within the ViewModel.
- Ensured `onStopRecording` and `finishRecorder` are called in `onCleared` of the ViewModel.
- Initialized the recorder by calling `setupRecorder()` in the `init` block of `AudioRecorderViewModel`.
- Removed `DisposableEffect` for recorder setup and teardown from `RecordingScreen` as it's now handled by the ViewModel's lifecycle.